### PR TITLE
Decrease update period to 6 hours

### DIFF
--- a/.github/workflows/periodic-update.yml
+++ b/.github/workflows/periodic-update.yml
@@ -2,7 +2,7 @@ name: periodic-update
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 0/12 * * *'
+    - cron:  '10 3/6 * * *'
 jobs:
   periodic-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want the latest Ultra-Rapid orbits and they are published every 6 hours at 03, 09, 15, 21 UTC. Looks like they are published 5 minutes too late: https://cddis.nasa.gov/archive/gnss/products/2211/
So updating 10 minutes after should be save.